### PR TITLE
Replace Pydantic V2's `Url` type with `AnyUrl` 

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,12 @@ History
 0.1.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Replace Pydantic V2's `Url` type with `AnyUrl` from
+  https://github.com/patrsc/pydantic-string-url/. The rationale being that URL
+  attributes on FHIR resources can (most of the times) passed on to HTTP
+  libraries without having to coerce or cast into `str`.
+
+  https://github.com/nazrulworld/fhir.resources/issues/164
 
 
 0.1.3 (2024-10-24)

--- a/fhir_core/types.py
+++ b/fhir_core/types.py
@@ -669,7 +669,6 @@ class Url:
         #    if realname:
         #        email = formataddr((name, email))
         #    return schema + email
-
         if isinstance(input_value, AnyUrl):
             return input_value
 
@@ -732,7 +731,10 @@ class Url:
 
         if typing.TYPE_CHECKING:
             assert inner_schema
-        return core_schema.with_info_wrap_validator_function(_validate, inner_schema)
+        return core_schema.with_info_wrap_validator_function(
+            _validate,
+            inner_schema
+        )
 
     @classmethod
     def to_string(cls, value):

--- a/fhir_core/yaml_utils.py
+++ b/fhir_core/yaml_utils.py
@@ -2,7 +2,8 @@ from collections import OrderedDict
 from datetime import datetime
 from decimal import Decimal
 
-from pydantic_core._pydantic_core import Url
+from pydantic_string_url import AnyUrl
+
 from yaml import Node, ScalarNode, YAMLError, dump, load
 from yaml.representer import Representer as BaseRepresenter
 from yaml.representer import SafeRepresenter
@@ -33,10 +34,9 @@ class Representer(SafeRepresenter):
         value = data.isoformat(sep="T")
         return self.represent_scalar("tag:yaml.org,2002:timestamp", value)
 
-    def represent_url(self, data: Url) -> Node:
-        """!!python/object/new:pydantic_core._pydantic_core.Url"""
-        coerced = str(data)
-        return self.represent_str(coerced)
+    def represent_url(self, data: AnyUrl) -> Node:
+        """!!python/object/new:pydantic_string_url.AnyUrl"""
+        return self.represent_str(str(data))
 
 
 BaseRepresenter.add_representer(
@@ -49,7 +49,7 @@ BaseRepresenter.add_representer(
     datetime, Representer.represent_datetime  # type: ignore[arg-type]
 )
 BaseRepresenter.add_representer(
-    Url, Representer.represent_url  # type: ignore[arg-type]
+    AnyUrl, Representer.represent_url  # type: ignore[arg-type]
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,10 @@ with open("README.rst") as readme_file:
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-requirements = ["pydantic>=2.7.4,<3.0"]
+requirements = [
+    "pydantic>=2.7.4,<3.0",
+    "pydantic-string-url"
+    ]
 if PY_VERSION_9_OR_EARLIER:
     requirements.append("eval-type-backport")
 
@@ -46,8 +49,6 @@ test_requirements = [
 ]
 if PY_VERSION_10_OR_LATER:
     test_requirements.append("importlib-metadata>=5.2.0")
-if PY_VERSION_11_OR_LATER:
-    test_requirements.append("typed-ast>=1.5.4")
 
 development_requirements = [
     "Jinja2==2.11.1",

--- a/tests/test_fhirabstractmodel.py
+++ b/tests/test_fhirabstractmodel.py
@@ -110,8 +110,8 @@ def test_model_dump_serialization():
     """ """
     from tests.fixtures.resources.account import Account
 
-    fileanme = STATIC_PATH / "account-example.json"
-    obj = Account.model_validate_json(fileanme.read_bytes())
+    filename = STATIC_PATH / "account-example.json"
+    obj = Account.model_validate_json(filename.read_bytes())
     serialized_data = obj.model_dump()
     assert Account.model_validate(serialized_data).model_dump() == serialized_data
     assert (
@@ -124,8 +124,8 @@ def test_general_resource_validation():
     """ """
     from tests.fixtures.resources.activitydefinition import ActivityDefinition
 
-    fileanme = STATIC_PATH / "activitydefinition-medicationorder-example.json"
-    obj = ActivityDefinition.model_validate_json(fileanme.read_bytes())
+    filename = STATIC_PATH / "activitydefinition-medicationorder-example.json"
+    obj = ActivityDefinition.model_validate_json(filename.read_bytes())
     serialized_data = obj.model_dump()
     assert (
         ActivityDefinition.model_validate(serialized_data).model_dump()
@@ -161,8 +161,8 @@ def test_base64binary_validation():
 
     from tests.fixtures.resources.auditevent import AuditEvent
 
-    fileanme = STATIC_PATH / "audit-event-example-search.json"
-    obj = AuditEvent.model_validate_json(fileanme.read_bytes())
+    filename = STATIC_PATH / "audit-event-example-search.json"
+    obj = AuditEvent.model_validate_json(filename.read_bytes())
     serialized_data = obj.model_dump()
     assert AuditEvent.model_validate(serialized_data).model_dump() == serialized_data
     assert (
@@ -175,8 +175,8 @@ def test_model_from_yaml():
     """ """
     from tests.fixtures.resources.activitydefinition import ActivityDefinition
 
-    fileanme = STATIC_PATH / "activitydefinition-medicationorder-example.yaml"
-    obj = ActivityDefinition.model_validate_yaml(fileanme.read_bytes())
+    filename = STATIC_PATH / "activitydefinition-medicationorder-example.yaml"
+    obj = ActivityDefinition.model_validate_yaml(filename.read_bytes())
     obj2 = ActivityDefinition.model_validate_json(
         (STATIC_PATH / "activitydefinition-medicationorder-example.json").read_bytes()
     )
@@ -187,9 +187,9 @@ def test_model_dump_yaml():
     """ """
     from tests.fixtures.resources.activitydefinition import ActivityDefinition
 
-    fileanme = STATIC_PATH / "activitydefinition-medicationorder-example.yaml"
+    filename = STATIC_PATH / "activitydefinition-medicationorder-example.yaml"
 
     obj = ActivityDefinition.model_validate_json(
         (STATIC_PATH / "activitydefinition-medicationorder-example.json").read_bytes()
     )
-    assert obj.model_dump_yaml() == fileanme.read_text()
+    assert obj.model_dump_yaml() == filename.read_text()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -156,3 +156,17 @@ def test_uri_type():
         minRules: fhir_types.UriType = Field(..., alias="minRules", title="Min Rules")
 
     assert MySimpleDateModel(minRules="None").model_dump()["minRules"] == "None"
+
+
+def test_url_type():
+    """ """
+
+    class MySimpleDateModel(BaseModel):
+        base_url: fhir_types.UrlType = Field(..., alias="base_url", title="Base URL")
+
+    model = MySimpleDateModel(base_url="https://example.com")
+    dumped = model.model_dump()["base_url"]
+
+    assert isinstance(dumped, str)
+    assert dumped == "https://example.com"
+    assert not dumped.endswith("/")


### PR DESCRIPTION
Replace Pydantic V2's `Url` type with `AnyUrl` from https://github.com/patrsc/pydantic-string-url/. The rationale being that URL attributes on FHIR resources can (most of the times) passed on to HTTP libraries without having to coerce or cast into `str`.

https://github.com/nazrulworld/fhir.resources/issues/164