### PR TITLE
Remove dependency on `typed-ast` 

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 0.1.4 (unreleased)
 ------------------
 
-- Remove dependency on `typed-ast` as it is needed and won't work in later Python versions.
+- Remove dependency on `typed-ast` as it is not needed and won't work in later Python versions.
 
 
 0.1.3 (2024-10-24)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 0.1.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove dependency on `typed-ast` as it is needed and won't work in later Python versions.
 
 
 0.1.3 (2024-10-24)

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,6 @@ test_requirements = [
 ]
 if PY_VERSION_10_OR_LATER:
     test_requirements.append("importlib-metadata>=5.2.0")
-if PY_VERSION_11_OR_LATER:
-    test_requirements.append("typed-ast>=1.5.4")
 
 development_requirements = [
     "Jinja2==2.11.1",


### PR DESCRIPTION
As it is not needed and won't work in later Python versions