### PR TITLE
fix integer64 maxsize

### DIFF
--- a/fhir_core/types.py
+++ b/fhir_core/types.py
@@ -492,14 +492,22 @@ class Integer(GroupedMetadata):
         return str(value)
 
 
-class Integer64(Integer):
+class Integer64(GroupedMetadata):
     """A signed integer in the range
     -9,223,372,036,854,775,808 to +9,223,372,036,854,775,807 (64-bit).
     This type is defined to allow for record/time counters that can get very large"""
 
-    min_length: int = -9223372036854775808
+    pattern = re.compile(r"^[0]|[-+]?[1-9][0-9]*$")
+
+    min_length: int = -9223372036854775807
     max_length: int = 9223372036854775807
     __visit_name__ = "integer64"
+
+    def __iter__(self) -> typing.Iterator[BaseMetadata]:
+        """ """
+        yield Le(self.max_length)
+
+        yield Ge(self.min_length)
 
 
 class UnsignedInt(Integer):

--- a/tests/fixtures/static/attachment-example.json
+++ b/tests/fixtures/static/attachment-example.json
@@ -1,0 +1,4 @@
+{
+    "resourceType": "Attachment",
+    "size": 9223372036854775807
+}

--- a/tests/test_fhirabstractmodel.py
+++ b/tests/test_fhirabstractmodel.py
@@ -194,3 +194,15 @@ def test_model_dump_yaml():
         (STATIC_PATH / "activitydefinition-medicationorder-example.json").read_bytes()
     )
     assert obj.model_dump_yaml() == filename.read_text()
+
+
+def test_model_attachment_max_size():
+    """ """
+    from tests.fixtures.resources.attachment import Attachment
+    import sys
+    filename = STATIC_PATH / "attachment-example.json"
+
+    attachment = Attachment.model_validate_json(
+        filename.read_bytes()
+    )
+    assert attachment.size == sys.maxsize, "Attachment.size should be sys.maxsize"


### PR DESCRIPTION
This PR:
* adds tests for integer64 fields, ensuring they validate for +/- sys.maxsize
* adds test for serializing Attachment, with size == sys.maxsize


Notes:

The code looks fine as is.  However, we were experiencing validation errors creating DocumentReference.attachment[0].size
```
 Input should be less than or equal to 2147483647 [type=less_than_equal, input_value='9223372036854775807', input_type=str]
```

However, for some non-obvious reason, the validator is using max/min from Integer

![image](https://github.com/user-attachments/assets/0ddb59cd-9228-4952-9b35-181fe75d056f)

This PR removes the inheritance between the Integer and Integer64 validators
