### PR TITLE
fix fhir.dateTime

### DIFF
--- a/fhir_core/types.py
+++ b/fhir_core/types.py
@@ -803,7 +803,21 @@ class Date:
                 Date or str.
 
             """
-            return cls._validate_date(input_value, validator)
+            validated_value = cls._validate_date(input_value, validator)
+            if (
+                cls.__name__ == DateTime.__name__
+                and isinstance(validated_value, datetime.datetime)
+                and isinstance(input_value, str)
+            ):
+                if "T" in input_value and validated_value.tzinfo is None:
+                    # a datetime with time MUST have a timezone
+                    raise ValueError(
+                        "Datetime must be timezone aware if it has a time component."
+                    )
+                if "T" not in input_value and validated_value.time():
+                    # a datetime without time MUST NOT have a time component
+                    validated_value = validated_value.date().isoformat()
+            return validated_value
 
         return core_schema.with_info_wrap_validator_function(
             _validate,

--- a/tests/static/json/examples/activitydefinition-medicationorder-example(citalopramPrescription).json
+++ b/tests/static/json/examples/activitydefinition-medicationorder-example(citalopramPrescription).json
@@ -93,7 +93,7 @@
   "title": "Citalopram Prescription",
   "status": "active",
   "experimental": true,
-  "date": "2015-08-15T00:00:00",
+  "date": "2015-08-15",
   "publisher": "HL7 International / Clinical Decision Support",
   "contact": [
     {

--- a/tests/static/yaml/examples/activitydefinition-medicationorder-example.yaml
+++ b/tests/static/yaml/examples/activitydefinition-medicationorder-example.yaml
@@ -117,7 +117,7 @@ name: CitalopramPrescription
 title: Citalopram Prescription
 status: active
 experimental: true
-date: 2015-08-15T00:00:00
+date: '2015-08-15'
 publisher: Motive Medical Intelligence
 contact:
 - telecom:
@@ -196,8 +196,8 @@ copyright: "\xA9 Copyright 2016 Motive Medical Intelligence. All rights reserved
 approvalDate: 2016-03-12
 lastReviewDate: 2016-08-15
 effectivePeriod:
-  start: 2016-01-01T00:00:00
-  end: 2017-12-31T00:00:00
+  start: '2016-01-01'
+  end: '2017-12-31'
 topic:
 - text: Mental Health Treatment
 author:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -197,3 +197,45 @@ def test_fhir_type_integer64():
         _ = (sys.maxsize + 1) * -1
         print(_)
         MyModel(size=_)
+
+
+class MySimpleDateModel(BaseModel):
+    time_stamp: fhir_types.DateTimeType = Field(..., alias="time_stamp", title="TimeStamp")
+
+
+def test_datetime_type_valid_timestamps():
+    """ """
+
+    GOOD_TIMESTAMP = "2016-09-09T12:00:00+00:00"
+    GOOD_TIMESTAMP_ZULU = "2016-09-09T12:00:00Z"
+    assert MySimpleDateModel(time_stamp=GOOD_TIMESTAMP).model_dump()["time_stamp"].isoformat() == GOOD_TIMESTAMP
+    assert MySimpleDateModel(time_stamp=GOOD_TIMESTAMP_ZULU).model_dump()["time_stamp"].isoformat() == GOOD_TIMESTAMP
+
+
+def test_datetime_type_invalid_timestamp():
+    """ If hours and minutes are specified, a time zone SHALL be populated. See https://hl7.org/fhir/datatypes.html#dateTime"""
+
+    BAD_TIMESTAMP = "2016-09-09T12:00:00"
+    with pytest.raises(ValidationError):
+        MySimpleDateModel(time_stamp=BAD_TIMESTAMP)
+
+
+def test_datetime_type_valid_yyyy_mm_dd():
+    """  partial date (e.g. just year or year + month). See https://hl7.org/fhir/datatypes.html#dateTime"""
+
+    PARTIAL_DATE = "2016-09-09"
+    assert f'"{PARTIAL_DATE}"' in MySimpleDateModel(time_stamp=PARTIAL_DATE).model_dump_json()
+
+
+def test_datetime_type_valid_yyyy_dd():
+    """  partial date (e.g. just year or year + month). See https://hl7.org/fhir/datatypes.html#dateTime"""
+
+    PARTIAL_DATE = "2016-09"
+    assert f'"{PARTIAL_DATE}"' in MySimpleDateModel(time_stamp=PARTIAL_DATE).model_dump_json()
+
+
+def test_datetime_type_valid_yyyy():
+    """  partial date (e.g. just year or year + month). See https://hl7.org/fhir/datatypes.html#dateTime"""
+
+    PARTIAL_DATE = "2016"
+    assert f'"{PARTIAL_DATE}"' in MySimpleDateModel(time_stamp=PARTIAL_DATE).model_dump_json()


### PR DESCRIPTION
This PR:
* throws validation error if datetime with timevalue supplied without a timezone `If hours and minutes are specified, a timezone offset SHALL be populated.`
* stores dates in the form of YYYY-MM-DD as strings, they were previously stored as datetime and rendered as "YYYY-MM-DDT00:00:00" without timezone

This may be open to interpretation, for more see: https://www.hl7.org/fhir/datatypes.html#dateTime
