### PR TITLE
fix:serialize Decimal as float

### DIFF
--- a/fhir_core/fhirabstractmodel.py
+++ b/fhir_core/fhirabstractmodel.py
@@ -434,6 +434,14 @@ class FHIRAbstractModel(BaseModel):
     ) -> typing.Any:
         """ """
 
+        import decimal
+
+        class DecimalEncoder:
+            @classmethod
+            def encode(cls, dec_value: decimal.Decimal) -> float:
+                """Encodes a Decimal as float."""
+                return float(dec_value)
+
         def _get_encoder():
             """ """
             for enc in field_info.metadata:
@@ -442,6 +450,8 @@ class FHIRAbstractModel(BaseModel):
                     return enc
             if "Base64Binary" in str(field_info.annotation):
                 return Base64Encoder
+            if "Decimal" in str(field_info.annotation):
+                return DecimalEncoder
 
         if isinstance(value, list):
             if len(value) == 0:
@@ -453,7 +463,7 @@ class FHIRAbstractModel(BaseModel):
 
         if value is None:
             return value
-        if isinstance(value, (bytes, bytearray)):
+        if isinstance(value, (bytes, bytearray, decimal.Decimal)):
             _enc_klass = _get_encoder()
             if _enc_klass:
                 return _enc_klass.encode(value)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -197,3 +197,17 @@ def test_fhir_type_integer64():
         _ = (sys.maxsize + 1) * -1
         print(_)
         MyModel(size=_)
+
+
+def test_fhir_type_quantity():
+
+    from pydantic import BaseModel
+    from tests.fixtures.resources.quantity import Quantity
+
+    class MyModel(BaseModel):
+        size: Quantity
+
+    _ = MyModel(size={"value": 10.101, "unit": "kg"})
+    assert float(_.size.value) == 10.101, "Should be 10.101"
+    serialized = _.model_dump_json()
+    assert '"10.101"' not in serialized, f"Decimal values should not have quotes {serialized}"


### PR DESCRIPTION
Ran into an issue where valueQuantity was serialized as str.  This PR  fixes serialization of Decimal types.
Related issue: https://github.com/pydantic/pydantic/issues/7120