### PR TITLE
Fix regression where input to Decimal type can lose exponent i.e. 1.0 remains 1.0 not 1

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,3 +12,4 @@ Contributors
 
 - Daniel Casals Amat [dacasals]
 - Chunhui Mo [cmodevcodes]
+- Fraser Stewart [fstewart-nhs]

--- a/fhir_core/types.py
+++ b/fhir_core/types.py
@@ -444,6 +444,9 @@ class Decimal:
             if not cls.pattern.fullmatch(str(input_value)):
                 raise ValueError("Decimal value string does not match spec regex.")
 
+            # Pass floats through str() so e.g. 1.0 becomes Decimal('1.0'), not Decimal('1').
+            if isinstance(input_value, float):
+                input_value = str(input_value)
             return decimal.Decimal(input_value)
 
         return core_schema.with_info_wrap_validator_function(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -138,6 +138,32 @@ def test_decimal_type():
     assert isinstance(model.point, decimal.Decimal)
 
 
+@pytest.mark.parametrize(
+    "raw_value,expected",
+    [
+        (1.0, 1.0),
+        (150.0, 150.0),
+        (100.0, 100.0),
+        (1234.5, 1234.5),
+        (1.01, 1.01),
+    ],
+)
+def test_decimal_whole_number_inputs_serialize_as_float(raw_value, expected):
+    """Float inputs to a Decimal field should preserve their exponent, so whole-number
+    floats (e.g. 100.0) serialise back to JSON with the exponent"""
+    import json
+
+    from tests.fixtures.resources.money import Money
+
+    money = Money.model_validate({"value": raw_value, "currency": "GBP"})
+    dumped = json.loads(money.model_dump_json())
+    assert isinstance(dumped["value"], float), (
+        f"Input {raw_value!r} serialised as "
+        f"{type(dumped['value']).__name__} ({dumped['value']!r}); expected float"
+    )
+    assert dumped["value"] == expected
+
+
 def test_date_type():
     """ """
 


### PR DESCRIPTION
Since release 1.1.8, `Money(value=1.00)` serializes to JSON as 1 instead of 1.0. 1.01 is fine, described in https://github.com/nazrulworld/fhir-core/issues/19

**Cause**
in 1.1.8 the serializer was changed in [PR18 ](https://github.com/nazrulworld/fhir-core/pull/18) so that the Decimal exponent is used to determine int vs float. Specifically that Decimal values of 1 or "1" do not have .0 exponents added. This however regressed Decimal values like 1.0, they now serialise as 1

**Fix**
In the Decimal validator, for float types convert to string before loading into Decimal. This preserves the exponent so 1.0 remains 1.0 and the fix in 1.1.8 is retained as this was downstream in the serializer, and string/int input types are not impacted.

**Tests**
Existing tests including those added in [PR18 ](https://github.com/nazrulworld/fhir-core/pull/18) pass, plus two regression tests added in test_types.py using Money.