### PR TITLE
Serialize the FHIR uuid type as urn:uuid:

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,8 @@ History
 1.1.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Serialize the FHIR ``uuid`` type as the URI the specification asks for,
+  ``urn:uuid:<uuid>``, instead of a bare UUID nazrulworld/fhir.resources#180
 
 
 1.1.10 (2026-07-25)

--- a/fhir_core/fhirabstractmodel.py
+++ b/fhir_core/fhirabstractmodel.py
@@ -1,6 +1,7 @@
 from __future__ import annotations as _annotations
 
 import decimal
+import uuid
 import inspect
 import logging
 import typing
@@ -586,6 +587,13 @@ class FHIRAbstractModel(BaseModel):
             _enc_klass = get_base64_encoder(field_info)
             if _enc_klass:
                 return _enc_klass.encode(value)
+        # @TODO: the function types.py#Uuid.__get_pydantic_core_schema__._serialize
+        # is not called either (see the Decimal note below), so the FHIR ``uuid``
+        # type, which is a URI and always carries the ``urn:uuid:`` scheme,
+        # is serialized from here as well.
+        # https://hl7.org/fhir/R5/datatypes.html#uuid
+        if isinstance(value, uuid.UUID):
+            return f"urn:uuid:{value}"
         # @TODO: the function types.py#Decimal.__get_pydantic_core_schema__._serialize
         # somehow is not called, until the reason is found, we serialize from here!
         if isinstance(value, decimal.Decimal):

--- a/tests/test_fhir_resource_issue_180.py
+++ b/tests/test_fhir_resource_issue_180.py
@@ -1,0 +1,53 @@
+import json
+import re
+import uuid
+
+from pydantic import Field
+
+from fhir_core.fhirabstractmodel import FHIRAbstractModel
+from fhir_core.types import UuidType
+
+# https://hl7.org/fhir/R5/datatypes.html#uuid
+SPEC_PATTERN = re.compile(
+    r"^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+
+class DummyUuidHolder(FHIRAbstractModel):
+    __resource_type__ = "DummyUuidHolder"
+
+    valueUuid: UuidType = Field(..., alias="valueUuid", title="Uuid value")
+
+    @classmethod
+    def elements_sequence(cls):
+        return ["valueUuid"]
+
+
+def test_fhir_core_uuid_serialization_issue_180():
+    """A FHIR uuid is a URI: it is written as urn:uuid:<uuid> or it does not
+    match the specification."""
+    canonical = "5f633a6a-398f-423c-a0d5-d254b51f487c"
+    expected = "urn:uuid:" + canonical
+
+    # every form the type accepts must come out as the same URI
+    for accepted in (
+        canonical,
+        expected,
+        "5f633a6a398f423ca0d5d254b51f487c",
+        canonical.upper(),
+        uuid.UUID(canonical),
+    ):
+        obj = DummyUuidHolder(valueUuid=accepted)
+        # the python-side type is unchanged
+        assert isinstance(obj.valueUuid, uuid.UUID)
+
+        assert obj.model_dump()["valueUuid"] == expected
+        data = json.loads(obj.model_dump_json())
+        assert data["valueUuid"] == expected
+        assert SPEC_PATTERN.match(data["valueUuid"])
+
+    # the prefix is not doubled when the output is read back and written again
+    obj = DummyUuidHolder(valueUuid=canonical)
+    for _ in range(3):
+        obj = DummyUuidHolder.model_validate_json(obj.model_dump_json())
+        assert json.loads(obj.model_dump_json())["valueUuid"] == expected


### PR DESCRIPTION
Fixes nazrulworld/fhir.resources#180.

`Extension(valueUuid="urn:uuid:5f633a6a-398f-423c-a0d5-d254b51f487c")` serializes back as `5f633a6a-398f-423c-a0d5-d254b51f487c`. In FHIR a `uuid` is a URI and the specification's regex requires the scheme, so the output does not validate:

```
urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
```

https://hl7.org/fhir/R5/datatypes.html#uuid

`UuidType` is `UUID4`, so the value is kept as a `uuid.UUID` and `str()` of it carries no prefix. The reporter saw this on 8.0.0 / 1.0.1; it still happens on 8.3.0 / 1.1.10 and on current main.

Making `Uuid` a `PatternConstraint` like its neighbour `Oid` is the obvious change, but it turns the field into a `str` and breaks two of your tests: `test_types.py::test_uuid` asserts `isinstance(model.myUUID, uuid.UUID)` and accepts the 32 hex short form, and `test_xml_utils.py::test_xml_represent` goes with it. A `field_serializer` on the type is not called either, for the same reason the `@TODO` above the `Decimal` branch describes. So this sits next to that branch in `_serialize_primitive_value` and is symmetric with it: the Python attribute stays a `uuid.UUID`, only the serialized form changes.

Since the value is stored as a `uuid.UUID` and not as a string, the prefix cannot end up doubled. Every input form the type accepts (bare, already prefixed, 32 hex, braced, uppercase, a `uuid.UUID` instance) comes out as the same URI, and repeated dump/parse cycles are stable. The test covers all of those.

```
pytest tests/test_fhir_resource_issue_180.py
```

fails on main and passes here. Full suite: 83 passed, 1 skipped, against 82 passed, 1 skipped before. I also installed `fhir.resources` 8.3.1.dev0 against this branch and ran its suite: 9 passed, unchanged. The JSON and XML output both carry the prefix, and it reaches the 10 `uuid` fields in R5, `Extension.valueUuid` and `ParametersParameter.valueUuid` among them.

Not overlapping with #22, which changes the type-level `Decimal` serializer in `types.py`; this only touches `fhirabstractmodel.py`.
