### PR TITLE
fix(types): restore lower bounds on UnsignedInt and PositiveInt

### DIFF
--- a/fhir_core/types.py
+++ b/fhir_core/types.py
@@ -506,20 +506,25 @@ class Integer64(GroupedMetadata):
         yield Ge(self.min_length)
 
 
+@dataclasses.dataclass(frozen=True, **SLOTS)
 class UnsignedInt(Integer):
     """Any non-negative integer in the range 0..2,147,483,647"""
 
     regex = re.compile(r"^[0]|([1-9][0-9]*)$")
     __visit_name__ = "unsignedInt"
-    min_length = 0
+    # Annotated and decorated so the narrower bound becomes this dataclass's
+    # field default. An unannotated class attribute is overwritten by the
+    # inherited __init__, which restores Integer's -2147483648 lower bound.
+    min_length: int = 0
 
 
+@dataclasses.dataclass(frozen=True, **SLOTS)
 class PositiveInt(UnsignedInt):
     """Any positive integer in the range 1..2,147,483,647"""
 
     regex = re.compile(r"^\+?[1-9][0-9]*$")
     __visit_name__ = "positiveInt"
-    min_length = 1
+    min_length: int = 1
 
 
 @dataclasses.dataclass(frozen=True, **SLOTS)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -187,6 +187,36 @@ def test_uri_type():
     assert MySimpleDateModel(minRules="None").model_dump()["minRules"] == "None"
 
 
+def test_fhir_type_unsigned_and_positive_int():
+    """Lower bounds must survive dataclass inheritance.
+
+    Regression test for nazrulworld/fhir.resources#207: UnsignedInt and
+    PositiveInt declared the narrower min_length as an unannotated class
+    attribute, so Integer's inherited __init__ reset it to -2147483648 and
+    negative values validated.
+    """
+    from fhir_core.types import PositiveInt, PositiveIntType, UnsignedInt, UnsignedIntType
+
+    assert PositiveInt().min_length == 1
+    assert UnsignedInt().min_length == 0
+
+    class Unsigned(BaseModel):
+        value: UnsignedIntType
+
+    class Positive(BaseModel):
+        value: PositiveIntType
+
+    assert Unsigned(value=0).value == 0
+    assert Positive(value=1).value == 1
+
+    with pytest.raises(ValidationError):
+        Unsigned(value=-1)
+    with pytest.raises(ValidationError):
+        Positive(value=0)
+    with pytest.raises(ValidationError):
+        Positive(value=-1)
+
+
 def test_fhir_type_integer64():
     import sys
 


### PR DESCRIPTION
Fixes nazrulworld/fhir.resources#207 — negative values validate against `unsignedInt` and `positiveInt` fields on 8.x.

```python
from fhir.resources.R4B.bundle import Bundle
from fhir.resources.R4B.timing import Timing

Bundle(type="searchset", total=-1)   # accepted
Timing(repeat={"count": 0})          # accepted
```

`Integer` is a frozen dataclass with `min_length` / `max_length` fields. `UnsignedInt` and `PositiveInt` narrowed `min_length` as *unannotated* class attributes, so they never became dataclass fields — the inherited `__init__` reset every instance to `Integer`'s `-2147483648`:

```python
>>> PositiveIntType
Annotated[int, PositiveInt(min_length=-2147483648, max_length=2147483647)]
>>> list(PositiveInt())
[Le(le=2147483647), Ge(ge=-2147483648)]
```

Annotating the overrides and decorating both subclasses makes the narrower bound the field default:

```python
>>> list(PositiveInt())
[Le(le=2147483647), Ge(ge=1)]
>>> list(UnsignedInt())
[Le(le=2147483647), Ge(ge=0)]
```

| Field | `-1` | `0` | `1` |
|---|---|---|---|
| `unsignedInt` | rejected | accepted | accepted |
| `positiveInt` | rejected | rejected | accepted |

Regression test in `tests/test_types.py`. Full suite: 84 passed, 1 skipped.

Also ran the downstream `fhir.resources` suite against this branch: identical to the unpatched baseline (608 failed / 717 passed both ways — those failures are pre-existing suite-order pollution, unrelated to this change).
