### PR TITLE
fix(xml): resolve FHIR version prefix through the class MRO

### DIFF
--- a/fhir_core/utils.py
+++ b/fhir_core/utils.py
@@ -119,6 +119,26 @@ def determine_version_prefix(class_or_module_path: str):
         return ""
 
 
+def determine_version_prefix_from_class(klass: typing.Any) -> str:
+    """Return the FHIR version prefix for ``klass``, searching its bases.
+
+    A user-defined subclass lives in its own module, which carries no version
+    segment. The version belongs to the generated class it inherits from, so
+    walk the MRO until a versioned module is found.
+
+    Args:
+        klass: The class to determine the version prefix for.
+
+    Returns:
+        The version prefix (e.g. ``"STU3."``), or ``""`` for the default version.
+    """
+    for candidate in getattr(klass, "__mro__", (klass,)):
+        prefix = determine_version_prefix(candidate.__module__)
+        if prefix:
+            return prefix
+    return ""
+
+
 @lru_cache(maxsize=1024, typed=True)
 def get_base64_encoder(field_info: FieldInfo) -> typing.Any:
     """ """
@@ -132,6 +152,8 @@ def get_base64_encoder(field_info: FieldInfo) -> typing.Any:
 
 
 __all__ = [
+    "determine_version_prefix",
+    "determine_version_prefix_from_class",
     "is_primitive_type",
     "get_fhir_type_name",
     "is_list_type",

--- a/fhir_core/xml_utils.py
+++ b/fhir_core/xml_utils.py
@@ -22,6 +22,7 @@ from pydantic_core._pydantic_core import Url
 
 from .utils import (
     determine_version_prefix,
+    determine_version_prefix_from_class,
     get_base64_encoder,
     get_fhir_type_name,
     is_list_type,
@@ -575,7 +576,7 @@ class Node:
         if parent is not None:
             version_prefix = parent.version_prefix
         elif fhir_class is not None:
-            version_prefix = determine_version_prefix(fhir_class.__module__)
+            version_prefix = determine_version_prefix_from_class(fhir_class)
         else:
             raise ValueError("Either 'parent' or 'fhir_class' must be provided.")
 
@@ -826,7 +827,7 @@ class Node:
     @classmethod
     def from_fhir_obj(cls, model: "FHIRAbstractModel"):
         """ """
-        version_prefix = determine_version_prefix(model.__module__)
+        version_prefix = determine_version_prefix_from_class(type(model))
         resource_node = cls(
             model.get_resource_type(),
             namespaces=[Namespace(None, ROOT_NS)],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -152,3 +152,31 @@ def test_is_list_type():
     assert utils.is_list_type(ActivityDefinition.model_fields["dosage"]) is True
     assert utils.is_list_type(ActivityDefinition.model_fields["doNotPerform"]) is False
     assert utils.is_list_type(Element.model_fields["extension"]) is True
+
+
+def test_determine_version_prefix_from_class():
+    """The version prefix is inherited from a versioned base class."""
+
+    class Versioned:
+        pass
+
+    # Generated resources live in modules like fhir.resources.STU3.patient
+    Versioned.__module__ = "fhir.resources.STU3.patient"
+
+    class UserSubclass(Versioned):
+        pass
+
+    UserSubclass.__module__ = "myapp.models"
+
+    assert utils.determine_version_prefix("fhir.resources.STU3.patient") == "STU3."
+    assert utils.determine_version_prefix("myapp.models") == ""
+
+    assert utils.determine_version_prefix_from_class(Versioned) == "STU3."
+    # Own module carries no version, so the base class supplies it
+    assert utils.determine_version_prefix_from_class(UserSubclass) == "STU3."
+
+    class Unversioned:
+        pass
+
+    Unversioned.__module__ = "fhir.resources.patient"
+    assert utils.determine_version_prefix_from_class(Unversioned) == ""

--- a/tests/test_xml_utils.py
+++ b/tests/test_xml_utils.py
@@ -79,6 +79,26 @@ def test_xml_node_patient_resource():
         raise AssertionError("code should not come here!")
 
 
+def test_xml_node_from_subclass_of_versioned_model():
+    """A user subclass keeps its parent's FHIR version prefix.
+
+    Regression test for nazrulworld/fhir.resources#209: the version prefix was
+    taken from the model's own module, so a subclass declared outside the
+    generated package resolved to no version and model_dump_xml raised
+    ValueError.
+    """
+
+    class MyPatient(Patient):
+        pass
+
+    patient = MyPatient.model_validate_json(
+        (STATIC_PATH_JSON_EXAMPLES / "patient-example.json").read_bytes()
+    )
+    # Raised ValueError before the fix
+    node = xml_utils.Node.from_fhir_obj(patient)
+    assert node.name == "Patient"
+
+
 def test_element_to_node():
     """ """
     from tests.fixtures.resources.patient import Patient


### PR DESCRIPTION
Fixes nazrulworld/fhir.resources#209 — `model_dump_xml()` raises a bare `ValueError` on any subclass of a generated resource.

```python
from fhir.resources.STU3.patient import Patient

class MyPatient(Patient):
    pass

MyPatient(name=[{"family": "family"}]).model_dump_xml()   # ValueError
Patient(name=[{"family": "family"}]).model_dump_xml()     # fine
```

`Node.from_fhir_obj` took the version prefix from `model.__module__`. A user subclass lives in its own module, which carries no version segment, so the prefix came back `""`, `get_fhir_type_name` looked up `"HumanName"` instead of `"STU3.HumanName"` in `FHIR_TYPES_MAPS`, missed, and raised.

Added `determine_version_prefix_from_class`, which walks the MRO until it finds a versioned module, and used it at both `Node` call sites. A subclass now inherits its base's version; base classes and default-version (R5) models are unchanged.

Verified for STU3, R4B and R5 subclasses, and that the base classes still serialize. Tests: a direct unit test of the new helper in `tests/test_utils.py` and a regression test in `tests/test_xml_utils.py`. Suite: 86 passed, 1 skipped.
