### PR TITLE
fix(serialization): keep elements whose subclass override drops the alias

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,3 +14,4 @@ Contributors
 - Chunhui Mo [cmodevcodes]
 - Fraser Stewart [fstewart-nhs]
 - Oliver Patterson [mrtreev]
+- Apoorv Saraogee [asaraog]

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,15 @@ History
 - Serialize the FHIR ``uuid`` type as the URI the specification asks for,
   ``urn:uuid:<uuid>``, instead of a bare UUID nazrulworld/fhir.resources#180
 
+- Restore the lower bounds on ``unsignedInt`` and ``positiveInt`` so negative
+  values no longer validate nazrulworld/fhir.resources#207 [asaraog]
+
+- Resolve the FHIR version prefix through the class MRO so ``model_dump_xml()``
+  works on subclasses nazrulworld/fhir.resources#209 [asaraog]
+
+- Fix ``KeyError`` during ``model_dump()`` when a subclass overrides a field's
+  default and drops its alias nazrulworld/fhir.resources#182 [asaraog]
+
 
 1.1.10 (2026-07-25)
 -------------------

--- a/fhir_core/fhirabstractmodel.py
+++ b/fhir_core/fhirabstractmodel.py
@@ -151,9 +151,14 @@ class FHIRAbstractModel(BaseModel):
     ) -> typing.Dict[str, str]:
         """Mappings between a field's name and alias"""
         aliases = cls.elements_sequence()
-        return {
-            fi.alias: fn for fn, fi in cls.model_fields.items() if fi.alias in aliases
-        }
+        mapping = {}
+        for field_name, field_info in cls.model_fields.items():
+            # A subclass may redeclare a field to change its default, which drops
+            # the generated alias. The field name is the element name in that case.
+            element_name = field_info.alias or field_name
+            if element_name in aliases:
+                mapping[element_name] = field_name
+        return mapping
 
     @classmethod
     def get_json_encoder(cls) -> typing.Callable[[typing.Any], typing.Any]:

--- a/tests/test_fhirabstractmodel.py
+++ b/tests/test_fhirabstractmodel.py
@@ -286,6 +286,28 @@ def test_model_from_xml():
     assert obj.model_dump() == obj2.model_dump()
 
 
+def test_model_dump_with_overridden_field_default():
+    """A subclass may redeclare a field to change its default.
+
+    Regression test for nazrulworld/fhir.resources#182: redeclaring a field drops
+    the generated alias, so the element fell out of get_alias_mapping() and
+    serialization raised KeyError.
+    """
+    from tests.fixtures.resources.attachment import Attachment
+
+    class MyAttachment(Attachment):
+        contentType: fhirtypes.CodeType = "text/plain"
+
+    assert MyAttachment.get_alias_mapping()["contentType"] == "contentType"
+
+    instance = MyAttachment(data=b"aGVsbG8=")
+    assert instance.model_dump()["contentType"] == "text/plain"
+
+    # The base class is unaffected
+    base = Attachment(data=b"aGVsbG8=", contentType="text/plain")
+    assert base.model_dump()["contentType"] == "text/plain"
+
+
 def test_model_dump_xml():
     """ """
     from tests.fixtures.resources.activitydefinition import ActivityDefinition


### PR DESCRIPTION
Fixes nazrulworld/fhir.resources#182 — `model_dump()` raises `KeyError` on a subclass that overrides a field's default.

```python
from fhir.resources.R4B.attachment import Attachment
from fhir.resources.R4B import fhirtypes

class MyCustomAttachment(Attachment):
    contentType: fhirtypes.CodeType = "text/plain"

MyCustomAttachment(data=data).model_dump()
# PydanticSerializationError: Error calling function `fhir_model_serializer`: KeyError: 'contentType'
```

`get_alias_mapping()` builds `{alias: field_name}` and skips any field whose `alias` is falsy. Redeclaring a field in a subclass replaces the generated `Field(..., alias="contentType")` with a plain annotation, so the alias is `None`, the element drops out of the mapping, and `_fhir_iter`'s `alias_maps[prop_name]` raises.

Fall back to the field name when no alias is set — for a redeclared field the field name *is* the element name. Generated classes always set an alias, so their mapping is unchanged.

Regression test in `tests/test_fhirabstractmodel.py`, covering the subclass and confirming the base class is unaffected. Suite: 84 passed, 1 skipped.
